### PR TITLE
Lower the elevator to the hardstop.

### DIFF
--- a/src/main/java/frc/robot/subsystems/elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/elevator/Elevator.java
@@ -156,7 +156,7 @@ public class Elevator extends SubsystemBase {
         break;
 
       case HARDSTOP:
-        height = JUST_ABOVE_HARDSTOP;
+        height = MIN_HEIGHT;
         break;
 
       default:


### PR DESCRIPTION
We used to lower to an inch above the hardstop and then stall against the hardstop. We don't need to do this anymore the way that we now structure the command.